### PR TITLE
bufix/43: implements apple token revocation use-case

### DIFF
--- a/integration-tests/src/test/java/io/quarkiverse/renarde/it/RenardeOidcTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/renarde/it/RenardeOidcTest.java
@@ -150,7 +150,7 @@ public class RenardeOidcTest {
                 .statusCode(302).extract().header("Location");
         Assertions.assertNotNull(findCookie(cookieFilter.getCookieStore(), "q_session_apple"));
         // add user (GET /oidc-success)
-        follow(url + "/_renarde/security/oidc-success", cookieFilter).statusCode(200);
+        follow(location.replace("https://", "http://"), cookieFilter).statusCode(200);
 
         // can access secure page
         given().when()

--- a/oidc-tests/src/main/java/io/quarkiverse/renarde/oidc/test/MockAppleOidcTestResource.java
+++ b/oidc-tests/src/main/java/io/quarkiverse/renarde/oidc/test/MockAppleOidcTestResource.java
@@ -35,6 +35,7 @@ public class MockAppleOidcTestResource extends MockOidcTestResource<MockAppleOid
         router.get("/auth/authorize").handler(this::authorize);
         router.post("/auth/token").handler(bodyHandler).handler(this::accessTokenJson);
         router.get("/auth/keys").handler(this::getKeys);
+        router.post("/auth/revoke").handler(this::revoke);
 
         KeyPairGenerator kpg;
         try {
@@ -73,6 +74,7 @@ public class MockAppleOidcTestResource extends MockOidcTestResource<MockAppleOid
     public Map<String, String> start() {
         Map<String, String> ret = super.start();
         ret.put("quarkus.oidc.apple.credentials.jwt.key-file", "test.oidc-apple-key.pem");
+        ret.put("quarkus.rest-client.RenardeAppleClient.url", baseURI);
         return ret;
     }
 
@@ -244,5 +246,21 @@ public class MockAppleOidcTestResource extends MockOidcTestResource<MockAppleOid
         rc.response()
                 .putHeader("Content-Type", "application/json")
                 .endAndForget(data);
+    }
+
+    /**
+     * POST /auth/revoke
+     * Host: appleid.apple.com
+     * Content-Type: application/x-www-form-urlencoded
+     *
+     * client_id=$1
+     * &client_secret=$2
+     * &token=$3
+     * &token_type_hint=access_token
+     *
+     * https://developer.apple.com/documentation/sign_in_with_apple/revoke_tokens/
+     */
+    private void revoke(RoutingContext rc) {
+        rc.response().setStatusCode(200).endAndForget();
     }
 }

--- a/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RenardeAppleClient.java
+++ b/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RenardeAppleClient.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.renarde.oidc.impl;
+
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(baseUri = "https://appleid.apple.com")
+public interface RenardeAppleClient {
+
+    @POST
+    @Path("/auth/revoke")
+    void revokeAppleUser(@FormParam("client_id") String clientID,
+            @FormParam("client_secret") String clientSecret,
+            @FormParam("token") String token,
+            @FormParam("token_type_hint") String tokenTypeHint);
+}

--- a/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RenardeRevokeController.java
+++ b/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RenardeRevokeController.java
@@ -27,7 +27,7 @@ import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 import io.smallrye.jwt.build.Jwt;
 
 @Path("_renarde/security")
-public class RernardeRevokeController extends Controller {
+public class RenardeRevokeController extends Controller {
 
     @Inject
     AccessTokenCredential accessToken;

--- a/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RernardeRevokeController.java
+++ b/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RernardeRevokeController.java
@@ -1,0 +1,86 @@
+package io.quarkiverse.renarde.oidc.impl;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkiverse.renarde.Controller;
+import io.quarkiverse.renarde.security.RenardeSecurity;
+import io.quarkus.oidc.AccessTokenCredential;
+import io.smallrye.jwt.algorithm.SignatureAlgorithm;
+import io.smallrye.jwt.build.Jwt;
+
+@Path("_renarde/security")
+public class RernardeRevokeController extends Controller {
+
+    @Inject
+    AccessTokenCredential accessToken;
+
+    @RestClient
+    RenardeAppleClient renardeAppleClient;
+
+    @ConfigProperty(name = "quarkus.oidc.apple.client-id")
+    String appleClientId;
+
+    @ConfigProperty(name = "quarkus.oidc.apple.credentials.jwt.issuer")
+    String appleOidcIssuer;
+
+    @ConfigProperty(name = "quarkus.oidc.apple.credentials.jwt.token-key-id")
+    String appleOidcKeyId;
+
+    @ConfigProperty(name = "quarkus.oidc.apple.credentials.jwt.key-file", defaultValue = "AuthKey_XXX.p8")
+    String appleKeyFile;
+
+    @Inject
+    public RenardeSecurity security;
+
+    /**
+     * Logout action, redirects to index
+     */
+    @Path("apple-revoke")
+    public Response revokeApple() {
+        String clientSecret = Jwt.audience("https://appleid.apple.com")
+                .subject(appleClientId)
+                .issuer(appleOidcIssuer)
+                .issuedAt(Instant.now().getEpochSecond())
+                .expiresIn(Duration.ofHours(1))
+                .jws()
+                .keyId(appleOidcKeyId)
+                .algorithm(SignatureAlgorithm.ES256)
+                .sign(getPrivateKey(String.format("src/main/resources/%s", appleKeyFile)));
+
+        // Revoke token access for apple user
+        renardeAppleClient.revokeAppleUser(appleClientId, clientSecret, accessToken.getToken(), "access_token");
+
+        return security.makeLogoutResponse();
+    }
+
+    private static PrivateKey getPrivateKey(String filename) {
+        try {
+            String content = Files.readString(Paths.get(filename));
+            String privateKey = content.replace("-----BEGIN PRIVATE KEY-----", "")
+                    .replace("-----END PRIVATE KEY-----", "")
+                    .replaceAll("\\s+", "");
+            KeyFactory kf = KeyFactory.getInstance("EC");
+            return kf.generatePrivate(new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateKey)));
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RernardeRevokeController.java
+++ b/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RernardeRevokeController.java
@@ -61,7 +61,6 @@ public class RernardeRevokeController extends Controller {
                 .keyId(appleOidcKeyId)
                 .algorithm(SignatureAlgorithm.ES256)
                 .sign(getPrivateKey(String.format("src/main/resources/%s", appleKeyFile)));
-        // Revoke token access for apple user
         renardeAppleClient.revokeAppleUser(appleClientId, clientSecret, accessToken.getToken(), "access_token");
         return security.makeLogoutResponse();
     }

--- a/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RernardeRevokeController.java
+++ b/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RernardeRevokeController.java
@@ -49,9 +49,7 @@ public class RernardeRevokeController extends Controller {
     @Inject
     public RenardeSecurity security;
 
-    /**
-     * Logout action, redirects to index
-     */
+
     @Path("apple-revoke")
     public Response revokeApple() {
         String clientSecret = Jwt.audience("https://appleid.apple.com")
@@ -63,10 +61,8 @@ public class RernardeRevokeController extends Controller {
                 .keyId(appleOidcKeyId)
                 .algorithm(SignatureAlgorithm.ES256)
                 .sign(getPrivateKey(String.format("src/main/resources/%s", appleKeyFile)));
-
         // Revoke token access for apple user
         renardeAppleClient.revokeAppleUser(appleClientId, clientSecret, accessToken.getToken(), "access_token");
-
         return security.makeLogoutResponse();
     }
 


### PR DESCRIPTION
Issue #43 [Add OIDC token revocation use-case](https://github.com/quarkiverse/quarkus-renarde/issues/43)
Add: 
* Security Controller to handle GET request `/apple-revoke`
° Use config to build apple signed token
° Use user's access token to call Apple revoke endpoint
° Makes a logout 

* Apple client to revoke access of an user (`/auth/revoke`)



[Usage example here](https://github.com/RasDeaks/quarkus-renarde-todo/pull/1)